### PR TITLE
优化简历模板时间显示逻辑：当结束时间为空时显示'至今'，当开始时间为空时不显示时间

### DIFF
--- a/src/template/templateA/index.vue
+++ b/src/template/templateA/index.vue
@@ -70,7 +70,7 @@
           <p class="school">
             <span>{{ edu.school }}({{ edu.degree }})</span>
             <span>{{ edu.major }}</span>
-            <b v-if="edu.startDate && edu.endDate">{{ edu.startDate }} 至 {{ edu.endDate }}</b>
+            <b v-if="edu.startDate">{{ edu.startDate }} 至 {{ edu.endDate || '至今' }}</b>
           </p>
         </div>
       </div>
@@ -92,8 +92,7 @@
             <div class="work-header">
               <span>{{ work.company }}</span>
               <span>{{ work.position }}</span>
-              <span>{{ work.startDate }} <span v-if="work.startDate && work.endDate">至</span> {{
-                formatEndDate(work.endDate) }}</span>
+              <span v-if="work.startDate">{{ work.startDate }} 至 {{ work.endDate || '至今' }}</span>
             </div>
           </div>
           <ul>
@@ -112,8 +111,7 @@
             <div class="project-header">
               <span>{{ project.projectName }}</span>
               <span>{{ project.role }}</span>
-              <span>{{ project.startDate }} <span v-if="project.startDate && project.endDate">至</span> {{
-                formatEndDate(project.endDate) }}</span>
+              <span v-if="project.startDate">{{ project.startDate }} 至 {{ project.endDate || '至今' }}</span>
             </div>
             <hr>
             <p class="project-introduction" v-html="marked(project.briefIntroduction)"></p>
@@ -144,7 +142,7 @@ const resume = computed(() => resumeStore.$state);
 
 // 处理结束日期的显示
 const formatEndDate = (endDate: string | null) => {
-  if (!endDate) return '';
+  if (!endDate) return '至今';
   const today = new Date();
   const end = new Date(endDate);
   return end > today ? '至今' : endDate;

--- a/src/template/templateB/index.vue
+++ b/src/template/templateB/index.vue
@@ -55,7 +55,7 @@
         <div class="experience-item" v-for="edu in resume.education" :key="edu.id">
           <div class="item-header">
             <h3 class="institution">{{ edu.school }}</h3>
-            <span class="duration">{{ edu.startDate }} - {{ edu.endDate }}</span>
+            <span v-if="edu.startDate" class="duration">{{ edu.startDate }} - {{ edu.endDate || '至今' }}</span>
           </div>
           <p class="degree">{{ edu.degree }} - {{ edu.major }}</p>
         </div>
@@ -78,7 +78,7 @@
           <div class="item-header">
             <p class="company">{{ work.company }}</p>
             <h3 class="position">{{ work.position }}</h3>
-            <span class="duration">{{ work.startDate }} - {{ formatEndDate(work.endDate) }}</span>
+            <span v-if="work.startDate" class="duration">{{ work.startDate }} - {{ work.endDate || '至今' }}</span>
           </div>
 
           <ul class="description-list">
@@ -96,7 +96,7 @@
           <div class="item-header">
             <h3 class="project-name">{{ project.projectName }}</h3>
             <p class="role">{{ project.role }}</p>
-            <span class="duration">{{ project.startDate }} - {{ formatEndDate(project.endDate) }}</span>
+            <span v-if="project.startDate" class="duration">{{ project.startDate }} - {{ project.endDate || '至今' }}</span>
           </div>
           <p class="project-intro" v-html="marked(project.briefIntroduction)"></p>
           <ul class="description-list">
@@ -125,7 +125,7 @@ const resume = computed(() => resumeStore.$state);
 
 // 处理结束日期的显示
 const formatEndDate = (endDate: string | null) => {
-  if (!endDate) return '';
+  if (!endDate) return '至今';
   const today = new Date();
   const end = new Date(endDate);
   return end > today ? '至今' : endDate;
@@ -250,8 +250,6 @@ watch(
   margin-bottom: var(--paragraph-spacing);
 }
 
-
-
 .experience-list {
   display: flex;
   flex-direction: column;
@@ -274,8 +272,6 @@ watch(
 .position,
 .project-name {
   font-size: 1rem;
-
-
 }
 
 .duration {

--- a/src/template/templateC/index.vue
+++ b/src/template/templateC/index.vue
@@ -52,7 +52,7 @@
           <h3>{{ edu.school }}</h3>
           <p class="edu-major">{{ edu.major }}</p>
           <p class="edu-degree">{{ edu.degree }}</p>
-          <p class="edu-time">{{ edu.startDate }} - {{ formatEndDate(edu.endDate) }}</p>
+          <p v-if="edu.startDate" class="edu-time">{{ edu.startDate }} - {{ edu.endDate || '至今' }}</p>
         </div>
       </div>
 
@@ -77,7 +77,7 @@
           <div class="exp-header">
             <h3>{{ work.company }}</h3>
             <div class="exp-role">{{ work.position }}</div>
-            <span class="exp-date">{{ work.startDate }} - {{ formatEndDate(work.endDate) }}</span>
+            <span v-if="work.startDate" class="exp-date">{{ work.startDate }} - {{ work.endDate || '至今' }}</span>
           </div>
 
           <div class="exp-desc" v-html="marked(work.description)"></div>
@@ -90,7 +90,7 @@
           <div class="proj-header">
             <h3>{{ project.projectName }}</h3>
             <div class="proj-role">{{ project.role }}</div>
-            <span class="proj-date">{{ project.startDate }} - {{ formatEndDate(project.endDate) }}</span>
+            <span v-if="project.startDate" class="proj-date">{{ project.startDate }} - {{ project.endDate || '至今' }}</span>
           </div>
 
           <div class="proj-brief" v-html="marked(project.briefIntroduction)"></div>
@@ -120,7 +120,7 @@ const resume = computed(() => resumeStore.$state);
 
 // 处理结束日期的显示
 const formatEndDate = (endDate: string | null) => {
-  if (!endDate) return '';
+  if (!endDate) return '至今';
   const today = new Date();
   const end = new Date(endDate);
   return end > today ? '至今' : endDate;
@@ -293,8 +293,6 @@ watch(
   position: relative;
   margin-right: 12px;
 }
-
-
 
 .skill-tag:last-child::after {
   display: none;

--- a/src/template/templateD/index.vue
+++ b/src/template/templateD/index.vue
@@ -57,7 +57,7 @@
             <span v-if="edu.major" class="major">{{ edu.major }}</span>
             <span v-if="edu.degree" class="degree">{{ edu.degree }}</span>
           </div>
-          <div class="edu-time">{{ edu.startDate }} ~ {{ edu.endDate }}</div>
+          <div v-if="edu.startDate" class="edu-time">{{ edu.startDate }} ~ {{ edu.endDate || '至今' }}</div>
         </div>
       </div>
     </section>
@@ -73,7 +73,7 @@
           <div class="work-header">
             <h3 class="company">{{ work.company }}</h3>
             <div v-if="work.position" class="position">{{ work.position }}</div>
-            <span class="time">{{ work.startDate }} ~ {{ work.endDate }}</span>
+            <span v-if="work.startDate" class="time">{{ work.startDate }} ~ {{ work.endDate || '至今' }}</span>
           </div>
 
           <div v-if="work.description" class="description" v-html="marked(work.description)"></div>
@@ -92,7 +92,7 @@
           <div class="project-header">
             <h3 class="project-name">{{ project.projectName }}</h3>
             <div v-if="project.role" class="role">{{ project.role }}</div>
-            <span class="time">{{ project.startDate }} ~ {{ project.endDate }}</span>
+            <span v-if="project.startDate" class="time">{{ project.startDate }} ~ {{ project.endDate || '至今' }}</span>
           </div>
 
           <div v-if="project.briefIntroduction" class="brief" v-html="marked(project.briefIntroduction)"></div>


### PR DESCRIPTION
#8 

## 修改内容
优化了简历模板的时间显示逻辑：
- 当结束时间为空时显示"至今"
- 当开始时间为空时不显示整个时间

## 修改原因
之前的逻辑中，如果不输入结束时间，整个时间都不会显示。
## 修改文件
- src/template/templateA/index.vue
- src/template/templateB/index.vue
- src/template/templateC/index.vue
- src/template/templateD/index.vue