### PR TITLE
feat: 简历模块、经历项支持用户拖拽排序

### DIFF
--- a/src/constants/sectionOrder.ts
+++ b/src/constants/sectionOrder.ts
@@ -1,0 +1,30 @@
+import type { SectionKey } from '../types/resume';
+
+export const DEFAULT_SECTION_ORDER: SectionKey[] = [
+  'personalInfo',
+  'education',
+  'projects',
+  'workExperience',
+  'skills',
+  'honors',
+  'summary'
+];
+
+export const normalizeSectionOrder = (order?: SectionKey[] | null): SectionKey[] => {
+  const result: SectionKey[] = [];
+  const source = Array.isArray(order) ? order : [];
+
+  for (const key of source) {
+    if (DEFAULT_SECTION_ORDER.includes(key) && !result.includes(key)) {
+      result.push(key);
+    }
+  }
+
+  for (const key of DEFAULT_SECTION_ORDER) {
+    if (!result.includes(key)) {
+      result.push(key);
+    }
+  }
+
+  return result;
+};

--- a/src/data/resumeDataTemplate.ts
+++ b/src/data/resumeDataTemplate.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_SECTION_ORDER } from '../constants/sectionOrder';
+
 export const resumeTemplate = {
   // 基本信息
   personalInfo: {
@@ -69,6 +71,7 @@ export const resumeTemplate = {
   ],
   // 自我评价
   summary: '',
+  sectionOrder: [...DEFAULT_SECTION_ORDER],
   // 简历设置
   resumeSetting: {
     themeColor1: "#3653c9",  // 主题颜色1（深色）

--- a/src/template/dev/index.vue
+++ b/src/template/dev/index.vue
@@ -2,7 +2,7 @@
   <!-- 简历容器，使用计算属性绑定所有主题相关的样式变量 -->
   <div class="resume-container" :style="resumeStyle">
     <!-- 个人信息部分 -->
-    <div class="personal-info">
+    <div class="personal-info" :style="sectionStyle('personalInfo')">
       <div class="personal-details">
         <!-- 仅在有值时显示对应的信息行 -->
         <div class="detail-row" v-if="resume.personalInfo.name">
@@ -49,7 +49,7 @@
     </div>
 
     <!-- 各个章节的模板结构相似，都包含标题和内容部分 -->
-    <div class="section education-section" v-if="resume.education.length">
+    <div class="section education-section" v-if="resume.education.length" :style="sectionStyle('education')">
       <div class="section-title">教育经历</div>
       <div class="section-content">
         <div class="item" v-for="edu in resume.education" :key="edu.id">
@@ -59,7 +59,7 @@
       </div>
     </div>
 
-    <div class="section experience-section" v-if="resume.workExperience.length">
+    <div class="section experience-section" v-if="resume.workExperience.length" :style="sectionStyle('workExperience')">
       <div class="section-title">工作经历</div>
       <div class="section-content">
         <div class="item" v-for="work in resume.workExperience" :key="work.id">
@@ -70,14 +70,14 @@
       </div>
     </div>
 
-    <div class="section skills-section" v-if="resume.skills.length">
+    <div class="section skills-section" v-if="resume.skills.length" :style="sectionStyle('skills')">
       <div class="section-title">技能特长</div>
       <div class="skills-list">
         <p v-for="skill in resume.skills" :key="skill.id" class="skill-item" v-html="marked(skill.skillName)"></p>
       </div>
     </div>
 
-    <div class="section projects-section" v-if="resume.projects.length">
+    <div class="section projects-section" v-if="resume.projects.length" :style="sectionStyle('projects')">
       <div class="section-title">项目经验</div>
       <div class="section-content">
         <div class="item" v-for="project in resume.projects" :key="project.id">
@@ -93,7 +93,7 @@
       </div>
     </div>
 
-    <div class="section honors-section" v-if="resume.honors.length">
+    <div class="section honors-section" v-if="resume.honors.length" :style="sectionStyle('honors')">
       <div class="section-title">荣誉奖项</div>
       <div class="section-content">
         <p v-for="honor in resume.honors" :key="honor.id" class="honor-item">
@@ -103,7 +103,7 @@
       </div>
     </div>
 
-    <div class="section summary-section" v-if="resume.summary">
+    <div class="section summary-section" v-if="resume.summary" :style="sectionStyle('summary')">
       <div class="section-title">自我评价</div>
       <p class="summary" v-html="marked(resume.summary)"></p>
     </div>
@@ -115,6 +115,8 @@ import { useResumeStore } from '../../store/useResumeStore';
 import { computed, watch, onMounted } from 'vue';
 import type { ColorShades } from '../../types/color';
 import { marked } from 'marked';
+import { normalizeSectionOrder } from '../../constants/sectionOrder';
+import type { SectionKey } from '../../types/resume';
 
 // 接受父组件传递的主题色
 const props = defineProps<{
@@ -140,6 +142,15 @@ const resumeStyle = computed(() => ({
   '--padding-top-bottom': `${resume.value.resumeSetting.padding_top_bottom}px`,
 }));
 
+const sectionOrder = computed<SectionKey[]>(() => normalizeSectionOrder(resume.value.sectionOrder));
+
+const sectionStyle = (key: SectionKey, offset = 0) => {
+  const index = sectionOrder.value.indexOf(key);
+  const base = index === -1 ? sectionOrder.value.length : index;
+  return {
+    order: base + offset,
+  };
+};
 // 组件挂载时设置字体大小
 onMounted(() => {
   updateFontSize();
@@ -172,6 +183,8 @@ watch(
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   box-sizing: border-box;
   font-size: 1rem;
+  display: flex;
+  flex-direction: column;
 }
 
 /* 移除所有动画效果 */
@@ -289,6 +302,8 @@ watch(
     margin: 0;
     padding: var(--padding-top-bottom) var(--padding-left-right);
     box-shadow: none;
+    display: flex;
+    flex-direction: column;
   }
 }
 </style>

--- a/src/template/templateA/index.vue
+++ b/src/template/templateA/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="resume-container" :style="resumeStyle">
     <!-- 个人信息 -->
-    <section class="personal-info">
+    <section class="personal-info" :style="sectionStyle('personalInfo')">
       <div class="personal-details">
         <div class="detail-row">
           <div class="detail-item name" v-if="resume.personalInfo.name">
@@ -55,7 +55,7 @@
     </section>
 
     <!-- 荣誉奖项、复用skills样式 -->
-    <section class="section skills-section" v-if="resume.honors.length">
+    <section class="section skills-section" v-if="resume.honors.length" :style="sectionStyle('honors')">
       <div class="section-title">荣誉奖项</div>
       <ul class="skills-list">
         <li v-for="honor in resume.honors" :key="honor.id" v-html="marked(honor.honorName)"></li>
@@ -63,7 +63,7 @@
     </section>
 
     <!-- 在校经历 -->
-    <section class="section education-section" v-if="resume.education.length">
+    <section class="section education-section" v-if="resume.education.length" :style="sectionStyle('education')">
       <div class="section-title">教育经历</div>
       <div class="section-content">
         <div class="item" v-for="edu in resume.education" :key="edu.id">
@@ -77,14 +77,14 @@
     </section>
 
     <!-- 技能特长 -->
-    <section class="section skills-section" v-if="resume.skills.length">
+    <section class="section skills-section" v-if="resume.skills.length" :style="sectionStyle('skills')">
       <div class="section-title">技能特长</div>
       <ul class="skills-list">
         <li v-for="skill in resume.skills" :key="skill.id" v-html="marked(skill.skillName)"></li>
       </ul>
     </section>
     <!-- 工作/实习经历 -->
-    <section class="section experience-section" v-if="resume.workExperience.length">
+    <section class="section experience-section" v-if="resume.workExperience.length" :style="sectionStyle('workExperience')">
       <div class="section-title">工作/实习经历</div>
       <div class="section-content">
         <div class="item" v-for="work in resume.workExperience" :key="work.id">
@@ -103,7 +103,7 @@
     </section>
 
     <!-- 项目经验 -->
-    <section class="section projects-section" v-if="resume.projects.length">
+    <section class="section projects-section" v-if="resume.projects.length" :style="sectionStyle('projects')">
       <div class="section-title">项目经验</div>
       <div class="section-content">
         <div class="item" v-for="project in resume.projects" :key="project.id">
@@ -124,7 +124,7 @@
     </section>
 
     <!-- 自我评价 -->
-    <section class="section self-evaluation-section" v-if="resume.summary">
+    <section class="section self-evaluation-section" v-if="resume.summary" :style="sectionStyle('summary')">
       <div class="section-title">自我评价</div>
       <p class="self-evaluation" v-html="marked(resume.summary)"></p>
     </section>
@@ -135,6 +135,8 @@
 import { useResumeStore } from '../../store/useResumeStore';
 import { computed, watch, onMounted } from 'vue';
 import { marked } from 'marked';
+import { normalizeSectionOrder } from '../../constants/sectionOrder';
+import type { SectionKey } from '../../types/resume';
 
 // 引入引用的store
 const resumeStore = useResumeStore();
@@ -152,6 +154,16 @@ const resumeStyle = computed(() => {
     '--themeColor2': resume.value.resumeSetting.themeColor2
   };
 });
+
+const sectionOrder = computed<SectionKey[]>(() => normalizeSectionOrder(resume.value.sectionOrder));
+
+const sectionStyle = (key: SectionKey, offset = 0) => {
+  const index = sectionOrder.value.indexOf(key);
+  const base = index === -1 ? sectionOrder.value.length : index;
+  return {
+    order: base + offset,
+  };
+};
 
 // 组件挂载时设置字体大小
 onMounted(() => {
@@ -180,6 +192,8 @@ watch(
   border-radius: 10px;
   box-sizing: border-box;
   font-family: 'zql', sans-serif;
+  display: flex;
+  flex-direction: column;
 }
 
 :deep(p) {

--- a/src/template/templateB/index.vue
+++ b/src/template/templateB/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="resume" :style="resumeStyle">
     <!-- 个人信息 -->
-    <section class="personal-section">
+    <section class="personal-section" :style="sectionStyle('personalInfo')">
       <div class="personal-info">
         <h1 class="name" v-if="resume.personalInfo.name">{{ resume.personalInfo.name }}</h1>
         <div class="info-grid">
@@ -38,10 +38,10 @@
     </section>
 
     <!-- 分割线 -->
-    <hr class="section-divider" />
+    <hr class="section-divider" :style="sectionStyle('personalInfo', 0.1)" />
 
     <!-- 荣誉奖项 -->
-    <section class="section" v-if="resume.honors.length">
+    <section class="section" v-if="resume.honors.length" :style="sectionStyle('honors')">
       <h2 class="section-title">荣誉奖项</h2>
       <ul class="list">
         <li v-for="honor in resume.honors" :key="honor.id" v-html="marked(honor.honorName)"></li>
@@ -49,7 +49,7 @@
     </section>
 
     <!-- 教育经历 -->
-    <section class="section" v-if="resume.education.length">
+    <section class="section" v-if="resume.education.length" :style="sectionStyle('education')">
       <h2 class="section-title">教育经历</h2>
       <div class="experience-list">
         <div class="experience-item" v-for="edu in resume.education" :key="edu.id">
@@ -63,7 +63,7 @@
     </section>
 
     <!-- 技能特长 -->
-    <section class="section" v-if="resume.skills.length">
+    <section class="section" v-if="resume.skills.length" :style="sectionStyle('skills')">
       <h2 class="section-title">技能特长</h2>
       <ul class="skill-list">
         <li v-for="skill in resume.skills" :key="skill.id">{{ skill.skillName }}</li>
@@ -71,7 +71,7 @@
     </section>
 
     <!-- 工作/实习经历 -->
-    <section class="section" v-if="resume.workExperience.length">
+    <section class="section" v-if="resume.workExperience.length" :style="sectionStyle('workExperience')">
       <h2 class="section-title">工作/实习经历</h2>
       <div class="experience-list">
         <div class="experience-item" v-for="work in resume.workExperience" :key="work.id">
@@ -89,7 +89,7 @@
     </section>
 
     <!-- 项目经验 -->
-    <section class="section" v-if="resume.projects.length">
+    <section class="section" v-if="resume.projects.length" :style="sectionStyle('projects')">
       <h2 class="section-title">项目经验</h2>
       <div class="experience-list">
         <div class="experience-item" v-for="project in resume.projects" :key="project.id">
@@ -108,7 +108,7 @@
     </section>
 
     <!-- 自我评价 -->
-    <section class="section" v-if="resume.summary">
+    <section class="section" v-if="resume.summary" :style="sectionStyle('summary')">
       <h2 class="section-title">自我评价</h2>
       <p class="summary" v-html="marked(resume.summary)"></p>
     </section>
@@ -119,6 +119,8 @@
 import { useResumeStore } from '../../store/useResumeStore';
 import { computed, watch, onMounted } from 'vue';
 import { marked } from 'marked';
+import { normalizeSectionOrder } from '../../constants/sectionOrder';
+import type { SectionKey } from '../../types/resume';
 
 // 引用的store
 const resumeStore = useResumeStore();
@@ -137,6 +139,15 @@ const resumeStyle = computed(() => {
   };
 });
 
+const sectionOrder = computed<SectionKey[]>(() => normalizeSectionOrder(resume.value.sectionOrder));
+
+const sectionStyle = (key: SectionKey, offset = 0) => {
+  const index = sectionOrder.value.indexOf(key);
+  const base = index === -1 ? sectionOrder.value.length : index;
+  return {
+    order: base + offset,
+  };
+};
 // 组件挂载时设置字体大小
 onMounted(() => {
   document.documentElement.style.fontSize = `${resume.value.resumeSetting.fontSize}px`;
@@ -160,6 +171,8 @@ watch(
   line-height: 1.6;
   max-width: 800px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .personal-section {

--- a/src/template/templateC/index.vue
+++ b/src/template/templateC/index.vue
@@ -2,7 +2,7 @@
   <div class="resume-container" :style="resumeStyle">
     <!-- 左侧边栏 -->
     <aside class="sidebar">
-      <div class="profile-section">
+      <div class="profile-section" :style="sectionStyle('personalInfo')">
         <div class="avatar-wrapper" v-if="resume.personalInfo.avatar">
           <img :src="resume.personalInfo.avatar" alt="头像" class="avatar">
         </div>
@@ -11,7 +11,7 @@
         </p>
       </div>
 
-      <div class="contact-section" v-if="hasContactInfo">
+      <div class="contact-section" v-if="hasContactInfo" :style="sectionStyle('personalInfo', 0.1)">
         <div class="contact-item" v-if="resume.personalInfo.gender">
           <i class="fas fa-user"></i>
           <span>性别：{{ resume.personalInfo.gender }}</span>
@@ -46,7 +46,7 @@
         </div>
       </div>
 
-      <div class="side-section" v-if="resume.education.length">
+      <div class="side-section" v-if="resume.education.length" :style="sectionStyle('education')">
         <h2 class="side-title">教育背景</h2>
         <div class="education-item" v-for="edu in resume.education" :key="edu.id">
           <h3>{{ edu.school }}</h3>
@@ -56,7 +56,7 @@
         </div>
       </div>
 
-      <div class="side-section" v-if="resume.skills.length">
+      <div class="side-section" v-if="resume.skills.length" :style="sectionStyle('skills')">
         <h2 class="side-title">技能特长</h2>
         <div class="skills-wrapper">
           <p class="skill-tag" v-for="skill in resume.skills" :key="skill.id" v-html="marked(skill.skillName)"></p>
@@ -66,12 +66,12 @@
 
     <!-- 主要内容区域 -->
     <main class="main-content">
-      <section class="content-section" v-if="resume.summary">
+      <section class="content-section" v-if="resume.summary" :style="sectionStyle('summary')">
         <h2 class="section-title">个人简介</h2>
         <p class="summary" v-html="marked(resume.summary)"></p>
       </section>
 
-      <section class="content-section" v-if="resume.workExperience.length">
+      <section class="content-section" v-if="resume.workExperience.length" :style="sectionStyle('workExperience')">
         <h2 class="section-title">工作经历</h2>
         <div class="experience-item" v-for="work in resume.workExperience" :key="work.id">
           <div class="exp-header">
@@ -84,7 +84,7 @@
         </div>
       </section>
 
-      <section class="content-section" v-if="resume.projects.length">
+      <section class="content-section" v-if="resume.projects.length" :style="sectionStyle('projects')">
         <h2 class="section-title">项目经验</h2>
         <div class="project-item" v-for="project in resume.projects" :key="project.id">
           <div class="proj-header">
@@ -99,7 +99,7 @@
         </div>
       </section>
 
-      <section class="content-section" v-if="resume.honors.length">
+      <section class="content-section" v-if="resume.honors.length" :style="sectionStyle('honors')">
         <h2 class="section-title">荣誉奖项</h2>
         <p v-for="honor in resume.honors" :key="honor.id" class="honor-item">
           <span v-html="marked(honor.honorName)"></span>
@@ -114,6 +114,8 @@
 import { useResumeStore } from '../../store/useResumeStore';
 import { computed, watch, onMounted } from 'vue';
 import { marked } from 'marked';
+import { normalizeSectionOrder } from '../../constants/sectionOrder';
+import type { SectionKey } from '../../types/resume';
 
 // 引用的store
 const resumeStore = useResumeStore();
@@ -138,6 +140,16 @@ const resumeStyle = computed(() => {
     '--themeColor2': resume.value.resumeSetting.themeColor2
   };
 });
+
+const sectionOrder = computed<SectionKey[]>(() => normalizeSectionOrder(resume.value.sectionOrder));
+
+const sectionStyle = (key: SectionKey, offset = 0) => {
+  const index = sectionOrder.value.indexOf(key);
+  const base = index === -1 ? sectionOrder.value.length : index;
+  return {
+    order: base + offset,
+  };
+};
 
 // 组件挂载时设置字体大小
 onMounted(() => {
@@ -298,6 +310,8 @@ watch(
   padding: calc(var(--padding-top-bottom) * 0.8) calc(var(--padding-left-right) * 0.8);
   background: white;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 }
 
 .content-section {

--- a/src/template/templateD/index.vue
+++ b/src/template/templateD/index.vue
@@ -2,7 +2,7 @@
   <div class="resume-container" :style="colorShadesStyle">
     <div class="header-decoration"></div>
     <!-- 头部信息区域 -->
-    <header class="resume-header">
+    <header class="resume-header" :style="sectionStyle('personalInfo')">
       <div class="header-content">
         <div class="header-main">
           <h1 class="name">{{ resume.personalInfo.name }}</h1>
@@ -36,7 +36,7 @@
     </header>
 
     <!-- 个人总结 -->
-    <section v-if="resume.summary" class="resume-section">
+    <section v-if="resume.summary" class="resume-section" :style="sectionStyle('summary')">
       <div class="section-icon">
         <i class="fas fa-user"></i>
       </div>
@@ -45,7 +45,7 @@
     </section>
 
     <!-- 教育经历 -->
-    <section v-if="resume.education.length" class="resume-section">
+    <section v-if="resume.education.length" class="resume-section" :style="sectionStyle('education')">
       <div class="section-icon">
         <i class="fas fa-graduation-cap"></i>
       </div>
@@ -63,7 +63,7 @@
     </section>
 
     <!-- 工作经历 -->
-    <section v-if="resume.workExperience.length" class="resume-section">
+    <section v-if="resume.workExperience.length" class="resume-section" :style="sectionStyle('workExperience')">
       <div class="section-icon">
         <i class="fas fa-briefcase"></i>
       </div>
@@ -82,7 +82,7 @@
     </section>
 
     <!-- 项目经历 -->
-    <section v-if="resume.projects.length" class="resume-section">
+    <section v-if="resume.projects.length" class="resume-section" :style="sectionStyle('projects')">
       <div class="section-icon">
         <i class="fas fa-project-diagram"></i>
       </div>
@@ -105,7 +105,7 @@
     </section>
 
     <!-- 技能特长 -->
-    <section v-if="resume.skills.length" class="resume-section">
+    <section v-if="resume.skills.length" class="resume-section" :style="sectionStyle('skills')">
       <div class="section-icon">
         <i class="fas fa-tools"></i>
       </div>
@@ -118,7 +118,7 @@
     </section>
 
     <!-- 荣誉奖项 -->
-    <section v-if="resume.honors.length" class="resume-section">
+    <section v-if="resume.honors.length" class="resume-section" :style="sectionStyle('honors')">
       <div class="section-icon">
         <i class="fas fa-award"></i>
       </div>
@@ -138,6 +138,8 @@ import { useResumeStore } from '../../store/useResumeStore';
 import { computed, watch, onMounted } from 'vue';
 import type { ColorShades } from '../../types/color';
 import { marked } from 'marked';
+import { normalizeSectionOrder } from '../../constants/sectionOrder';
+import type { SectionKey } from '../../types/resume';
 
 // 接受父组件的主题色
 const props = defineProps<{
@@ -160,6 +162,16 @@ const colorShadesStyle = computed(() => ({
   '--padding-left-right': `${resume.value.resumeSetting.padding_left_right}px`,
   '--padding-top-bottom': `${resume.value.resumeSetting.padding_top_bottom}px`,
 }));
+
+const sectionOrder = computed<SectionKey[]>(() => normalizeSectionOrder(resume.value.sectionOrder));
+
+const sectionStyle = (key: SectionKey, offset = 0) => {
+  const index = sectionOrder.value.indexOf(key);
+  const base = index === -1 ? sectionOrder.value.length : index;
+  return {
+    order: base + offset,
+  };
+};
 
 // 组件挂载时设置字体大小
 onMounted(() => {
@@ -197,6 +209,8 @@ watch(
   box-sizing: border-box;
   font-size: 1rem;
   /* 使用相对单位，基于根元素字体大小 */
+  display: flex;
+  flex-direction: column;
 }
 
 /* 移除所有动画效果和设置盒模型 */
@@ -271,6 +285,8 @@ li {
     box-shadow: none;
     min-height: 297mm;
     font-size: 1rem;
+    display: flex;
+    flex-direction: column;
   }
 }
 
@@ -515,6 +531,8 @@ li {
 @media (max-width: 768px) {
   .resume-container {
     padding: 15px;
+    display: flex;
+    flex-direction: column;
   }
 
   .resume-header {

--- a/src/types/resume.d.ts
+++ b/src/types/resume.d.ts
@@ -55,6 +55,16 @@ export interface Honor {
 }
 
 
+export type SectionKey =
+  | 'personalInfo'
+  | 'education'
+  | 'projects'
+  | 'workExperience'
+  | 'skills'
+  | 'honors'
+  | 'summary';
+
+
 export interface ResumeSetting {
   themeColor1: string;  // 主题颜色1（深色）
   themeColor2: string;  // 主题颜色2（浅色）
@@ -74,6 +84,7 @@ export interface ResumeState {
   projects: Project[];
   honors: Honor[];
   summary: string;
+  sectionOrder: SectionKey[];
   currentId: number;
   isFirstVisit: boolean;
   resumeSetting: ResumeSetting;

--- a/src/utils/reorder.ts
+++ b/src/utils/reorder.ts
@@ -1,0 +1,13 @@
+export const moveItem = <T>(list: T[], from: number, to: number) => {
+  if (from === to) return;
+  if (from < 0 || from >= list.length) return;
+
+  const [item] = list.splice(from, 1);
+  if (item === undefined) return;
+
+  let targetIndex = to;
+  if (targetIndex < 0) targetIndex = 0;
+  if (targetIndex > list.length) targetIndex = list.length;
+
+  list.splice(targetIndex, 0, item);
+};

--- a/src/views/resume/components/education.vue
+++ b/src/views/resume/components/education.vue
@@ -171,14 +171,14 @@ watch(
 .education-item {
   width: 100%;
   position: relative;
-  padding-left: 28px;
   border-radius: 8px;
 }
 
 .item-header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
+  gap: 12px;
   margin-bottom: 16px;
 }
 
@@ -186,13 +186,14 @@ watch(
   margin: 0;
 }
 
+.item-header > :last-child {
+  justify-self: end;
+}
+
 .item-drag-handle {
-  position: absolute;
-  left: 0;
-  top: 16px;
   width: 24px;
   height: 24px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: grab;

--- a/src/views/resume/components/education.vue
+++ b/src/views/resume/components/education.vue
@@ -3,8 +3,27 @@
     <a-collapse-panel key="1" header="教育经历">
       <a-space direction="vertical" style="width: 100%">
         <!-- 教育经历列表 -->
-        <div v-for="(edu, index) in education" :key="index" class="education-item">
+        <div
+          v-for="(edu, index) in education"
+          :key="edu.id"
+          class="education-item"
+          :class="{ 'is-drag-over': dragOverIndex === index }"
+          @dragenter.prevent="onDragEnter(index)"
+          @dragover.prevent="onDragOver(index, $event)"
+          @dragleave="onDragLeave(index)"
+          @drop="onDrop(index, $event)"
+        >
           <div class="item-header">
+            <button
+              class="item-drag-handle"
+              type="button"
+              draggable="true"
+              aria-label="拖拽调整教育经历顺序"
+              @dragstart="onDragStart(index, $event)"
+              @dragend="onDragEnd"
+            >
+              <MenuOutlined />
+            </button>
             <h4>教育经历 #{{ index + 1 }}</h4>
             <a-popconfirm title="确定要删除当前教育经历？" ok-text="删除" cancel-text="取消" @confirm="removeEducation(edu.id)">
               <template #icon><question-circle-outlined style="color: red" /></template>
@@ -48,13 +67,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue';
-import { PlusOutlined } from '@ant-design/icons-vue';
+import { computed, ref, watch } from 'vue';
+import { PlusOutlined, MenuOutlined } from '@ant-design/icons-vue';
 import { useResumeStore } from '../../../store';
 import { QuestionCircleOutlined } from '@ant-design/icons-vue';
 import { message } from 'ant-design-vue';
+import { moveItem } from '../../../utils/reorder';
 const resumeStore = useResumeStore();
 const education = computed(() => resumeStore.education);
+const draggingIndex = ref<number | null>(null);
+const dragOverIndex = ref<number | null>(null);
 
 // 添加教育经历
 const addEducation = () => {
@@ -71,6 +93,61 @@ const addEducation = () => {
 const removeEducation = (id: number) => {
   resumeStore.deleteEducation(id)
   message.success('教育经历删除成功！');
+};
+
+const onDragStart = (index: number, event: DragEvent) => {
+  draggingIndex.value = index;
+  dragOverIndex.value = null;
+  event.dataTransfer?.setData('text/plain', String(index));
+  event.dataTransfer && (event.dataTransfer.effectAllowed = 'move');
+};
+
+const onDragEnd = () => {
+  draggingIndex.value = null;
+  dragOverIndex.value = null;
+};
+
+const onDragEnter = (index: number) => {
+  if (draggingIndex.value === null || draggingIndex.value === index) return;
+  dragOverIndex.value = index;
+};
+
+const onDragLeave = (index: number) => {
+  if (dragOverIndex.value === index) {
+    dragOverIndex.value = null;
+  }
+};
+
+const onDragOver = (index: number, event: DragEvent) => {
+  if (draggingIndex.value === null) return;
+  event.dataTransfer && (event.dataTransfer.dropEffect = 'move');
+  if (dragOverIndex.value !== index && draggingIndex.value !== index) {
+    dragOverIndex.value = index;
+  }
+};
+
+const onDrop = (index: number, event: DragEvent) => {
+  event.preventDefault();
+  if (draggingIndex.value === null) return;
+  const currentTarget = event.currentTarget as HTMLElement | null;
+  let toIndex = index;
+  if (currentTarget) {
+    const rect = currentTarget.getBoundingClientRect();
+    const offset = event.clientY - rect.top;
+    if (offset > rect.height / 2) {
+      toIndex = index + 1;
+    }
+  }
+  const fromIndex = draggingIndex.value;
+  if (fromIndex < toIndex) {
+    toIndex -= 1;
+  }
+  if (fromIndex !== toIndex) {
+    moveItem(education.value, fromIndex, toIndex);
+    resumeStore.saveToLocalStorage();
+  }
+  draggingIndex.value = null;
+  dragOverIndex.value = null;
 };
 
 // 监听变化并保存到 localStorage
@@ -93,6 +170,9 @@ watch(
 
 .education-item {
   width: 100%;
+  position: relative;
+  padding-left: 28px;
+  border-radius: 8px;
 }
 
 .item-header {
@@ -104,5 +184,29 @@ watch(
 
 .item-header h4 {
   margin: 0;
+}
+
+.item-drag-handle {
+  position: absolute;
+  left: 0;
+  top: 16px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  border: none;
+  background: transparent;
+  color: #8c8c8c;
+  padding: 0;
+}
+
+.item-drag-handle:active {
+  cursor: grabbing;
+}
+
+.education-item.is-drag-over {
+  outline: 2px dashed #1677ff;
 }
 </style>

--- a/src/views/resume/components/honor.vue
+++ b/src/views/resume/components/honor.vue
@@ -165,14 +165,14 @@ watch(
 .honor-item {
   width: 100%;
   position: relative;
-  padding-left: 28px;
   border-radius: 8px;
 }
 
 .item-header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
+  gap: 12px;
   margin-bottom: 16px;
 }
 
@@ -180,13 +180,14 @@ watch(
   margin: 0;
 }
 
+.item-header > :last-child {
+  justify-self: end;
+}
+
 .item-drag-handle {
-  position: absolute;
-  left: 0;
-  top: 16px;
   width: 24px;
   height: 24px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: grab;

--- a/src/views/resume/components/honor.vue
+++ b/src/views/resume/components/honor.vue
@@ -3,8 +3,27 @@
     <a-collapse-panel key="1" header="荣誉奖项">
       <a-space direction="vertical" style="width: 100%">
         <!-- 荣誉列表 -->
-        <div v-for="(honor, index) in honors" :key="index" class="honor-item">
+        <div
+          v-for="(honor, index) in honors"
+          :key="honor.id"
+          class="honor-item"
+          :class="{ 'is-drag-over': dragOverIndex === index }"
+          @dragenter.prevent="onDragEnter(index)"
+          @dragover.prevent="onDragOver(index, $event)"
+          @dragleave="onDragLeave(index)"
+          @drop="onDrop(index, $event)"
+        >
           <div class="item-header">
+            <button
+              class="item-drag-handle"
+              type="button"
+              draggable="true"
+              aria-label="拖拽调整荣誉顺序"
+              @dragstart="onDragStart(index, $event)"
+              @dragend="onDragEnd"
+            >
+              <MenuOutlined />
+            </button>
             <h4>荣誉 #{{ index + 1 }}</h4>
             <a-popconfirm title="确定要删除当前荣誉奖项？" ok-text="删除" cancel-text="取消" @confirm="removeHonor(honor.id)">
               <template #icon><question-circle-outlined style="color: red" /></template>
@@ -44,15 +63,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue';
-import { PlusOutlined } from '@ant-design/icons-vue';
+import { computed, ref, watch } from 'vue';
+import { PlusOutlined, MenuOutlined } from '@ant-design/icons-vue';
 import { useResumeStore } from '../../../store';
 import { QuestionCircleOutlined } from '@ant-design/icons-vue';
 import { message } from 'ant-design-vue';
 import AIEnhancePopover from './AIEnhancePopover.vue';
+import { moveItem } from '../../../utils/reorder';
 const resumeStore = useResumeStore();
 const honors = computed(() => resumeStore.honors);
-console.log(honors.value)
+const draggingIndex = ref<number | null>(null);
+const dragOverIndex = ref<number | null>(null);
 // 添加荣誉
 const addHonor = () => {
   resumeStore.addHonor({
@@ -66,6 +87,61 @@ const addHonor = () => {
 const removeHonor = (id: number) => {
   resumeStore.deleteHonor(id)
   message.success('荣誉奖项删除成功！');
+};
+
+const onDragStart = (index: number, event: DragEvent) => {
+  draggingIndex.value = index;
+  dragOverIndex.value = null;
+  event.dataTransfer?.setData('text/plain', String(index));
+  event.dataTransfer && (event.dataTransfer.effectAllowed = 'move');
+};
+
+const onDragEnd = () => {
+  draggingIndex.value = null;
+  dragOverIndex.value = null;
+};
+
+const onDragEnter = (index: number) => {
+  if (draggingIndex.value === null || draggingIndex.value === index) return;
+  dragOverIndex.value = index;
+};
+
+const onDragLeave = (index: number) => {
+  if (dragOverIndex.value === index) {
+    dragOverIndex.value = null;
+  }
+};
+
+const onDragOver = (index: number, event: DragEvent) => {
+  if (draggingIndex.value === null) return;
+  event.dataTransfer && (event.dataTransfer.dropEffect = 'move');
+  if (dragOverIndex.value !== index && draggingIndex.value !== index) {
+    dragOverIndex.value = index;
+  }
+};
+
+const onDrop = (index: number, event: DragEvent) => {
+  event.preventDefault();
+  if (draggingIndex.value === null) return;
+  const currentTarget = event.currentTarget as HTMLElement | null;
+  let toIndex = index;
+  if (currentTarget) {
+    const rect = currentTarget.getBoundingClientRect();
+    const offset = event.clientY - rect.top;
+    if (offset > rect.height / 2) {
+      toIndex = index + 1;
+    }
+  }
+  const fromIndex = draggingIndex.value;
+  if (fromIndex < toIndex) {
+    toIndex -= 1;
+  }
+  if (fromIndex !== toIndex) {
+    moveItem(honors.value, fromIndex, toIndex);
+    resumeStore.saveToLocalStorage();
+  }
+  draggingIndex.value = null;
+  dragOverIndex.value = null;
 };
 
 // 监听变化并保存到 localStorage
@@ -88,6 +164,9 @@ watch(
 
 .honor-item {
   width: 100%;
+  position: relative;
+  padding-left: 28px;
+  border-radius: 8px;
 }
 
 .item-header {
@@ -99,5 +178,29 @@ watch(
 
 .item-header h4 {
   margin: 0;
+}
+
+.item-drag-handle {
+  position: absolute;
+  left: 0;
+  top: 16px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  border: none;
+  background: transparent;
+  color: #8c8c8c;
+  padding: 0;
+}
+
+.item-drag-handle:active {
+  cursor: grabbing;
+}
+
+.honor-item.is-drag-over {
+  outline: 2px dashed #1677ff;
 }
 </style>

--- a/src/views/resume/components/project.vue
+++ b/src/views/resume/components/project.vue
@@ -3,8 +3,27 @@
     <a-collapse-panel key="1" header="项目经历">
       <a-space direction="vertical" style="width: 100%">
         <!-- 项目经历列表 -->
-        <div v-for="(project, index) in projects" :key="project.id" class="project-item">
+        <div
+          v-for="(project, index) in projects"
+          :key="project.id"
+          class="project-item"
+          :class="{ 'is-drag-over': dragOverIndex === index }"
+          @dragenter.prevent="onDragEnter(index)"
+          @dragover.prevent="onDragOver(index, $event)"
+          @dragleave="onDragLeave(index)"
+          @drop="onDrop(index, $event)"
+        >
           <div class="item-header">
+            <button
+              class="item-drag-handle"
+              type="button"
+              draggable="true"
+              aria-label="拖拽调整项目经历顺序"
+              @dragstart="onDragStart(index, $event)"
+              @dragend="onDragEnd"
+            >
+              <MenuOutlined />
+            </button>
             <h4>项目经历 #{{ index + 1 }}</h4>
             <a-popconfirm title="确定要删除当前项目经历？" ok-text="删除" cancel-text="取消" @confirm="removeProject(project.id)">
               <template #icon><question-circle-outlined style="color: red" /></template>
@@ -64,14 +83,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue';
-import { PlusOutlined } from '@ant-design/icons-vue';
+import { computed, ref, watch } from 'vue';
+import { PlusOutlined, MenuOutlined } from '@ant-design/icons-vue';
 import { useResumeStore } from '../../../store';
 import { QuestionCircleOutlined } from '@ant-design/icons-vue';
 import { message } from 'ant-design-vue';
 import AIEnhancePopover from './AIEnhancePopover.vue';
+import { moveItem } from '../../../utils/reorder';
 const resumeStore = useResumeStore();
 const projects = computed(() => resumeStore.projects);
+const draggingIndex = ref<number | null>(null);
+const dragOverIndex = ref<number | null>(null);
 
 // 添加项目经历
 const addProject = () => {
@@ -89,6 +111,61 @@ const addProject = () => {
 const removeProject = (id: number) => {
   resumeStore.deleteProject(id);
   message.success('项目经历删除成功！');
+};
+
+const onDragStart = (index: number, event: DragEvent) => {
+  draggingIndex.value = index;
+  dragOverIndex.value = null;
+  event.dataTransfer?.setData('text/plain', String(index));
+  event.dataTransfer && (event.dataTransfer.effectAllowed = 'move');
+};
+
+const onDragEnd = () => {
+  draggingIndex.value = null;
+  dragOverIndex.value = null;
+};
+
+const onDragEnter = (index: number) => {
+  if (draggingIndex.value === null || draggingIndex.value === index) return;
+  dragOverIndex.value = index;
+};
+
+const onDragLeave = (index: number) => {
+  if (dragOverIndex.value === index) {
+    dragOverIndex.value = null;
+  }
+};
+
+const onDragOver = (index: number, event: DragEvent) => {
+  if (draggingIndex.value === null) return;
+  event.dataTransfer && (event.dataTransfer.dropEffect = 'move');
+  if (dragOverIndex.value !== index && draggingIndex.value !== index) {
+    dragOverIndex.value = index;
+  }
+};
+
+const onDrop = (index: number, event: DragEvent) => {
+  event.preventDefault();
+  if (draggingIndex.value === null) return;
+  const currentTarget = event.currentTarget as HTMLElement | null;
+  let toIndex = index;
+  if (currentTarget) {
+    const rect = currentTarget.getBoundingClientRect();
+    const offset = event.clientY - rect.top;
+    if (offset > rect.height / 2) {
+      toIndex = index + 1;
+    }
+  }
+  const fromIndex = draggingIndex.value;
+  if (fromIndex < toIndex) {
+    toIndex -= 1;
+  }
+  if (fromIndex !== toIndex) {
+    moveItem(projects.value, fromIndex, toIndex);
+    resumeStore.saveToLocalStorage();
+  }
+  draggingIndex.value = null;
+  dragOverIndex.value = null;
 };
 
 // 监听变化并保存到 localStorage
@@ -111,6 +188,9 @@ watch(
 
 .project-item {
   width: 100%;
+  position: relative;
+  padding-left: 28px;
+  border-radius: 8px;
 }
 
 .item-header {
@@ -122,5 +202,29 @@ watch(
 
 .item-header h4 {
   margin: 0;
+}
+
+.item-drag-handle {
+  position: absolute;
+  left: 0;
+  top: 16px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  border: none;
+  background: transparent;
+  color: #8c8c8c;
+  padding: 0;
+}
+
+.item-drag-handle:active {
+  cursor: grabbing;
+}
+
+.project-item.is-drag-over {
+  outline: 2px dashed #1677ff;
 }
 </style>

--- a/src/views/resume/components/project.vue
+++ b/src/views/resume/components/project.vue
@@ -189,14 +189,14 @@ watch(
 .project-item {
   width: 100%;
   position: relative;
-  padding-left: 28px;
   border-radius: 8px;
 }
 
 .item-header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
+  gap: 12px;
   margin-bottom: 16px;
 }
 
@@ -204,13 +204,14 @@ watch(
   margin: 0;
 }
 
+.item-header > :last-child {
+  justify-self: end;
+}
+
 .item-drag-handle {
-  position: absolute;
-  left: 0;
-  top: 16px;
   width: 24px;
   height: 24px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: grab;

--- a/src/views/resume/components/resumeEdit.vue
+++ b/src/views/resume/components/resumeEdit.vue
@@ -1,36 +1,147 @@
 <template>
   <div class="resume-edit">
-    <a-alert message="现已经支持部分区域渲染markdown或HTML语法（如技能、项目等）" show-icon type="info" style="margin-bottom: 10px;" />
-    <!-- 个人信息编辑组件 -->
-    <personalInfo />
-
-    <!-- 教育经历 -->
-    <education />
-
-    <!-- 项目经历 -->
-    <project />
-    <!-- 工作经历 -->
-    <workExperience />
-
-    <!-- 专业技能 -->
-    <skill />
-
-    <!-- 荣誉奖项 -->
-    <honor />
-
-    <!-- 自我评价 -->
-    <selfEvaluation />
+    <a-alert
+      message="现已经支持部分区域渲染markdown或HTML语法（如技能、项目等）"
+      show-icon
+      type="info"
+      style="margin-bottom: 10px;"
+    />
+    <div
+      v-for="module in orderedModules"
+      :key="module.key"
+      class="module-wrapper"
+      :class="{ 'is-drag-over': dragOverModule === module.key }"
+      @dragenter.prevent="onModuleDragEnter(module.key)"
+      @dragover.prevent="onModuleDragOver(module.key, $event)"
+      @dragleave="onModuleDragLeave(module.key)"
+      @drop="onModuleDrop(module.key, $event)"
+    >
+      <button
+        class="module-drag-handle"
+        type="button"
+        draggable="true"
+        :aria-label="`拖拽调整${module.label}模块顺序`"
+        @dragstart="onModuleDragStart(module.key, $event)"
+        @dragend="onModuleDragEnd"
+      >
+        <MenuOutlined />
+      </button>
+      <component :is="module.component" />
+    </div>
+    <div
+      v-show="draggingModule"
+      class="module-drop-zone"
+      @dragenter.prevent
+      @dragover.prevent
+      @drop="onDropToEnd"
+    >
+      <MenuOutlined />
+      <span>拖拽到此处将模块放在最后</span>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { Component } from 'vue';
+import { MenuOutlined } from '@ant-design/icons-vue';
+import { useResumeStore } from '../../../store';
+import type { SectionKey } from '../../../types/resume';
 import personalInfo from './personalInfo.vue';
 import education from './education.vue';
 import workExperience from './workExperience.vue';
 import skill from './skill.vue';
 import honor from './honor.vue';
 import selfEvaluation from './selfEvaluation.vue';
-import project from './project.vue';  
+import project from './project.vue';
+
+type ModuleDefinition = {
+  key: SectionKey;
+  label: string;
+  component: Component;
+};
+
+const moduleDefinitions: ModuleDefinition[] = [
+  { key: 'personalInfo', label: '个人信息', component: personalInfo },
+  { key: 'education', label: '教育经历', component: education },
+  { key: 'projects', label: '项目经历', component: project },
+  { key: 'workExperience', label: '工作经历', component: workExperience },
+  { key: 'skills', label: '专业技能', component: skill },
+  { key: 'honors', label: '荣誉奖项', component: honor },
+  { key: 'summary', label: '自我评价', component: selfEvaluation }
+];
+
+const moduleMap = new Map<SectionKey, ModuleDefinition>(
+  moduleDefinitions.map(definition => [definition.key, definition])
+);
+
+const resumeStore = useResumeStore();
+
+const orderedModules = computed(() =>
+  resumeStore.sectionOrder
+    .map(key => moduleMap.get(key))
+    .filter((module): module is ModuleDefinition => Boolean(module))
+);
+
+const draggingModule = ref<SectionKey | null>(null);
+const dragOverModule = ref<SectionKey | null>(null);
+
+const onModuleDragStart = (key: SectionKey, event: DragEvent) => {
+  draggingModule.value = key;
+  dragOverModule.value = null;
+  event.dataTransfer?.setData('text/plain', key);
+  event.dataTransfer && (event.dataTransfer.effectAllowed = 'move');
+};
+
+const onModuleDragEnd = () => {
+  draggingModule.value = null;
+  dragOverModule.value = null;
+};
+
+const onModuleDragEnter = (key: SectionKey) => {
+  if (!draggingModule.value || draggingModule.value === key) return;
+  dragOverModule.value = key;
+};
+
+const onModuleDragLeave = (key: SectionKey) => {
+  if (dragOverModule.value === key) {
+    dragOverModule.value = null;
+  }
+};
+
+const onModuleDragOver = (key: SectionKey, event: DragEvent) => {
+  if (!draggingModule.value) return;
+  event.dataTransfer && (event.dataTransfer.dropEffect = 'move');
+  if (dragOverModule.value !== key && draggingModule.value !== key) {
+    dragOverModule.value = key;
+  }
+};
+
+const onModuleDrop = (key: SectionKey, event: DragEvent) => {
+  event.preventDefault();
+  if (!draggingModule.value) return;
+  const currentTarget = event.currentTarget as HTMLElement | null;
+  let placement: 'before' | 'after' = 'before';
+  if (currentTarget) {
+    const rect = currentTarget.getBoundingClientRect();
+    if (event.clientY - rect.top > rect.height / 2) {
+      placement = 'after';
+    }
+  }
+  resumeStore.moveSection(draggingModule.value, key, placement);
+  draggingModule.value = null;
+  dragOverModule.value = null;
+};
+
+const onDropToEnd = (event: DragEvent) => {
+  event.preventDefault();
+  if (!draggingModule.value) return;
+  const nextOrder = resumeStore.sectionOrder.filter(item => item !== draggingModule.value);
+  nextOrder.push(draggingModule.value);
+  resumeStore.setSectionOrder(nextOrder);
+  draggingModule.value = null;
+  dragOverModule.value = null;
+};
 </script>
 
 <style scoped>
@@ -40,5 +151,54 @@ import project from './project.vue';
   overflow-y: auto;
   /* 滚动条细 */
   scrollbar-width: thin;
+}
+
+.module-wrapper {
+  position: relative;
+  padding-left: 28px;
+  margin-bottom: 16px;
+  border-radius: 10px;
+}
+
+.module-wrapper.is-drag-over {
+  outline: 2px dashed #1677ff;
+}
+
+.module-drag-handle {
+  position: absolute;
+  left: 0;
+  top: 12px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  border: none;
+  background: transparent;
+  color: #8c8c8c;
+  padding: 0;
+}
+
+.module-drag-handle:active {
+  cursor: grabbing;
+}
+
+.module-drop-zone {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px dashed #c0c4cc;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: #8c8c8c;
+  font-size: 12px;
+  background: #f7f7f7;
+}
+
+.module-drop-zone svg {
+  font-size: 16px;
 }
 </style>

--- a/src/views/resume/components/skill.vue
+++ b/src/views/resume/components/skill.vue
@@ -155,14 +155,14 @@ watch(
 .skill-item {
   width: 100%;
   position: relative;
-  padding-left: 28px;
   border-radius: 8px;
 }
 
 .item-header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
+  gap: 12px;
   margin-bottom: 16px;
 }
 
@@ -170,13 +170,14 @@ watch(
   margin: 0;
 }
 
+.item-header > :last-child {
+  justify-self: end;
+}
+
 .item-drag-handle {
-  position: absolute;
-  left: 0;
-  top: 16px;
   width: 24px;
   height: 24px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: grab;

--- a/src/views/resume/components/skill.vue
+++ b/src/views/resume/components/skill.vue
@@ -3,8 +3,27 @@
     <a-collapse-panel key="1" header="专业技能">
       <a-space direction="vertical" style="width: 100%">
         <!-- 技能列表 -->
-        <div v-for="(skill, index) in skills" :key="index" class="skill-item">
+        <div
+          v-for="(skill, index) in skills"
+          :key="skill.id"
+          class="skill-item"
+          :class="{ 'is-drag-over': dragOverIndex === index }"
+          @dragenter.prevent="onDragEnter(index)"
+          @dragover.prevent="onDragOver(index, $event)"
+          @dragleave="onDragLeave(index)"
+          @drop="onDrop(index, $event)"
+        >
           <div class="item-header">
+            <button
+              class="item-drag-handle"
+              type="button"
+              draggable="true"
+              aria-label="拖拽调整技能顺序"
+              @dragstart="onDragStart(index, $event)"
+              @dragend="onDragEnd"
+            >
+              <MenuOutlined />
+            </button>
             <h4>技能 #{{ index + 1 }}</h4>
             <a-popconfirm title="确定要删除当前技能？" ok-text="删除" cancel-text="取消" @confirm="removeSkill(skill.id)">
               <template #icon><question-circle-outlined style="color: red" /></template>
@@ -34,15 +53,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue';
-import { PlusOutlined } from '@ant-design/icons-vue';
+import { computed, ref, watch } from 'vue';
+import { PlusOutlined, MenuOutlined } from '@ant-design/icons-vue';
 import { useResumeStore } from '../../../store';
 import { QuestionCircleOutlined } from '@ant-design/icons-vue';
 import { message } from 'ant-design-vue';
 import AIEnhancePopover from './AIEnhancePopover.vue';
+import { moveItem } from '../../../utils/reorder';
 
 const resumeStore = useResumeStore();
 const skills = computed(() => resumeStore.skills);
+const draggingIndex = ref<number | null>(null);
+const dragOverIndex = ref<number | null>(null);
 
 // 添加技能
 const addSkill = () => {
@@ -55,6 +77,61 @@ const addSkill = () => {
 const removeSkill = (id: number) => {
   resumeStore.deleteSkill(id)
   message.success('技能删除成功！');
+};
+
+const onDragStart = (index: number, event: DragEvent) => {
+  draggingIndex.value = index;
+  dragOverIndex.value = null;
+  event.dataTransfer?.setData('text/plain', String(index));
+  event.dataTransfer && (event.dataTransfer.effectAllowed = 'move');
+};
+
+const onDragEnd = () => {
+  draggingIndex.value = null;
+  dragOverIndex.value = null;
+};
+
+const onDragEnter = (index: number) => {
+  if (draggingIndex.value === null || draggingIndex.value === index) return;
+  dragOverIndex.value = index;
+};
+
+const onDragLeave = (index: number) => {
+  if (dragOverIndex.value === index) {
+    dragOverIndex.value = null;
+  }
+};
+
+const onDragOver = (index: number, event: DragEvent) => {
+  if (draggingIndex.value === null) return;
+  event.dataTransfer && (event.dataTransfer.dropEffect = 'move');
+  if (dragOverIndex.value !== index && draggingIndex.value !== index) {
+    dragOverIndex.value = index;
+  }
+};
+
+const onDrop = (index: number, event: DragEvent) => {
+  event.preventDefault();
+  if (draggingIndex.value === null) return;
+  const currentTarget = event.currentTarget as HTMLElement | null;
+  let toIndex = index;
+  if (currentTarget) {
+    const rect = currentTarget.getBoundingClientRect();
+    const offset = event.clientY - rect.top;
+    if (offset > rect.height / 2) {
+      toIndex = index + 1;
+    }
+  }
+  const fromIndex = draggingIndex.value;
+  if (fromIndex < toIndex) {
+    toIndex -= 1;
+  }
+  if (fromIndex !== toIndex) {
+    moveItem(skills.value, fromIndex, toIndex);
+    resumeStore.saveToLocalStorage();
+  }
+  draggingIndex.value = null;
+  dragOverIndex.value = null;
 };
 
 // 监听变化并保存到 localStorage
@@ -77,6 +154,9 @@ watch(
 
 .skill-item {
   width: 100%;
+  position: relative;
+  padding-left: 28px;
+  border-radius: 8px;
 }
 
 .item-header {
@@ -88,5 +168,29 @@ watch(
 
 .item-header h4 {
   margin: 0;
+}
+
+.item-drag-handle {
+  position: absolute;
+  left: 0;
+  top: 16px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  border: none;
+  background: transparent;
+  color: #8c8c8c;
+  padding: 0;
+}
+
+.item-drag-handle:active {
+  cursor: grabbing;
+}
+
+.skill-item.is-drag-over {
+  outline: 2px dashed #1677ff;
 }
 </style>

--- a/src/views/resume/components/workExperience.vue
+++ b/src/views/resume/components/workExperience.vue
@@ -181,14 +181,14 @@ watch(
 .experience-item {
   width: 100%;
   position: relative;
-  padding-left: 28px;
   border-radius: 8px;
 }
 
 .item-header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
+  gap: 12px;
   margin-bottom: 16px;
 }
 
@@ -196,13 +196,14 @@ watch(
   margin: 0;
 }
 
+.item-header > :last-child {
+  justify-self: end;
+}
+
 .item-drag-handle {
-  position: absolute;
-  left: 0;
-  top: 16px;
   width: 24px;
   height: 24px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: grab;

--- a/src/views/resume/components/workExperience.vue
+++ b/src/views/resume/components/workExperience.vue
@@ -3,8 +3,27 @@
     <a-collapse-panel key="1" header="工作经历">
       <a-space direction="vertical" style="width: 100%">
         <!-- 工作经历列表 -->
-        <div v-for="(work, index) in workExperience" :key="index" class="experience-item">
+        <div
+          v-for="(work, index) in workExperience"
+          :key="work.id"
+          class="experience-item"
+          :class="{ 'is-drag-over': dragOverIndex === index }"
+          @dragenter.prevent="onDragEnter(index)"
+          @dragover.prevent="onDragOver(index, $event)"
+          @dragleave="onDragLeave(index)"
+          @drop="onDrop(index, $event)"
+        >
           <div class="item-header">
+            <button
+              class="item-drag-handle"
+              type="button"
+              draggable="true"
+              aria-label="拖拽调整工作经历顺序"
+              @dragstart="onDragStart(index, $event)"
+              @dragend="onDragEnd"
+            >
+              <MenuOutlined />
+            </button>
             <h4>工作经历 #{{ index + 1 }}</h4>
             <a-popconfirm title="确定要删除当前技能？" ok-text="删除" cancel-text="取消" @confirm="removeWork(work.id)">
               <template #icon><question-circle-outlined style="color: red" /></template>
@@ -57,14 +76,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue';
-import { PlusOutlined } from '@ant-design/icons-vue';
+import { computed, ref, watch } from 'vue';
+import { PlusOutlined, MenuOutlined } from '@ant-design/icons-vue';
 import { useResumeStore } from '../../../store';
 import { QuestionCircleOutlined } from '@ant-design/icons-vue';
 import AIEnhancePopover from './AIEnhancePopover.vue';
 import { message } from 'ant-design-vue';
+import { moveItem } from '../../../utils/reorder';
 const resumeStore = useResumeStore();
 const workExperience = computed(() => resumeStore.workExperience);
+const draggingIndex = ref<number | null>(null);
+const dragOverIndex = ref<number | null>(null);
 
 // 添加工作经历
 const addWork = () => {
@@ -81,6 +103,61 @@ const addWork = () => {
 const removeWork = (id: number) => {
   resumeStore.deleteWorkExperience(id)
   message.success('工作经历删除成功！');
+};
+
+const onDragStart = (index: number, event: DragEvent) => {
+  draggingIndex.value = index;
+  dragOverIndex.value = null;
+  event.dataTransfer?.setData('text/plain', String(index));
+  event.dataTransfer && (event.dataTransfer.effectAllowed = 'move');
+};
+
+const onDragEnd = () => {
+  draggingIndex.value = null;
+  dragOverIndex.value = null;
+};
+
+const onDragEnter = (index: number) => {
+  if (draggingIndex.value === null || draggingIndex.value === index) return;
+  dragOverIndex.value = index;
+};
+
+const onDragLeave = (index: number) => {
+  if (dragOverIndex.value === index) {
+    dragOverIndex.value = null;
+  }
+};
+
+const onDragOver = (index: number, event: DragEvent) => {
+  if (draggingIndex.value === null) return;
+  event.dataTransfer && (event.dataTransfer.dropEffect = 'move');
+  if (dragOverIndex.value !== index && draggingIndex.value !== index) {
+    dragOverIndex.value = index;
+  }
+};
+
+const onDrop = (index: number, event: DragEvent) => {
+  event.preventDefault();
+  if (draggingIndex.value === null) return;
+  const currentTarget = event.currentTarget as HTMLElement | null;
+  let toIndex = index;
+  if (currentTarget) {
+    const rect = currentTarget.getBoundingClientRect();
+    const offset = event.clientY - rect.top;
+    if (offset > rect.height / 2) {
+      toIndex = index + 1;
+    }
+  }
+  const fromIndex = draggingIndex.value;
+  if (fromIndex < toIndex) {
+    toIndex -= 1;
+  }
+  if (fromIndex !== toIndex) {
+    moveItem(workExperience.value, fromIndex, toIndex);
+    resumeStore.saveToLocalStorage();
+  }
+  draggingIndex.value = null;
+  dragOverIndex.value = null;
 };
 
 // 监听变化并保存到 localStorage
@@ -103,6 +180,9 @@ watch(
 
 .experience-item {
   width: 100%;
+  position: relative;
+  padding-left: 28px;
+  border-radius: 8px;
 }
 
 .item-header {
@@ -114,5 +194,29 @@ watch(
 
 .item-header h4 {
   margin: 0;
+}
+
+.item-drag-handle {
+  position: absolute;
+  left: 0;
+  top: 16px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  border: none;
+  background: transparent;
+  color: #8c8c8c;
+  padding: 0;
+}
+
+.item-drag-handle:active {
+  cursor: grabbing;
+}
+
+.experience-item.is-drag-over {
+  outline: 2px dashed #1677ff;
 }
 </style>


### PR DESCRIPTION
## Summary
- add drag-and-drop handles for module cards and list entries in the resume editor so users can reorder sections and items
- persist a sectionOrder sequence in the resume store with normalization helpers and reusable move logic
- update resume templates to render blocks according to the configurable order

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cea46ec87c833090a9b9342ab5df34